### PR TITLE
Fixed 'failed to load system roots and no roots provided' error.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM debian:jessie
+RUN apt-get update && apt-get install -y ca-certificates
 COPY bin/who-is-who  /usr/bin/who-is-who
 CMD ["who-is-who"]


### PR DESCRIPTION
Got explanation and solution from here: http://blog.cloud66.com/x509-error-when-using-https-inside-a-docker-container/