### PR TITLE
Fixed bug for aws username generation

### DIFF
--- a/integrations/cleverAWS/aws.go
+++ b/integrations/cleverAWS/aws.go
@@ -22,7 +22,8 @@ type AwsService struct{}
 func (a AwsService) Fill(m integrations.UserMap) (integrations.UserMap, error) {
 	for email, user := range m {
 		if user.FirstName != "" && user.LastName != "" {
-			user.AWS = strings.ToLower(user.FirstName[0:1] + user.LastName)
+			lastName := strings.Replace(user.LastName, " ", "", -1)
+			user.AWS = strings.ToLower(user.FirstName[0:1] + lastName)
 		}
 		m[email] = user
 	}

--- a/integrations/cleverAWS/aws_test.go
+++ b/integrations/cleverAWS/aws_test.go
@@ -1,0 +1,29 @@
+package cleveraws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Clever/who-is-who/integrations"
+)
+
+func TestAWS(t *testing.T) {
+	assert := assert.New(t)
+
+	userMap := integrations.UserMap{
+		"who@car.es": integrations.User{
+			FirstName: "First Name",
+			LastName:  "Last Name",
+		},
+	}
+	service := AwsService{}
+
+	userMap, err := service.Fill(userMap)
+	assert.NoError(err)
+	assert.Equal(1, len(userMap))
+
+	user, ok := userMap["who@car.es"]
+	assert.True(ok)
+	assert.Equal("flastname", user.AWS)
+}


### PR DESCRIPTION
It'd create invalid aws names if the user had a space in their last name.