### PR TITLE
Who-is-who merges objects with the same email address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ format:
 
 run: lint
 	docker build -t who-is-who .
-	@docker run -p 8080:80 --env-file=<(echo -e $(_ARKLOC_ENV_FILE)) who-is-who
+	@docker run -p 8081:80 --env-file=<(echo -e $(_ARKLOC_ENV_FILE)) who-is-who

--- a/db.js
+++ b/db.js
@@ -163,11 +163,19 @@ module.exports = function(storage) {
           return cb(err);
         }
 
+        // Before creating a new object, try to find pre-existing object using email prop.
+        // Should be effective since all new objects must have an email prop.
+        if(obj == null && key !== "email") {
+          body = _.set(body, key, val); // Here so key/val pair isn't lost
+
+          return this.put(author, "email", body["email"], body, cb);
+        }
+
         let prev = obj || {_whoid: uuid()};
         let cur = _.defaultsDeep({}, body, prev);
-        cur = _.set(cur, key, val); // Here to ensure new values have the correct index
-
         cur = removeEmptyValues(cur); // Don't save empty values
+
+        if(key === "email") { cur.email = val; }
 
         if (!cur.email) {
           return cb(UserError("Can't save.  No email address found."));

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "eslint": "^3.10.2",
     "node-mocks-http": "^1.5.4",
-    "nodeunit": "^0.10.2",
+    "nodeunit": "^0.11.0",
     "prettier": "^0.18.0"
   }
 }

--- a/tests/test-routes.js
+++ b/tests/test-routes.js
@@ -400,6 +400,30 @@ exports["/alias/`key`/`value`"] = {
       });
     });
   },
+  "POST, PUT editting email address works": test => {
+    test.expect(7);
+
+    mockPOST("/alias/email/poop@poop.com", {slack: "poop"}, (res, data) => {
+      test.equal(res.statusCode, 200);
+      test.deepEqual(data, {slack: "poop", email: "poop@poop.com"});
+
+      mockPOST("/alias/slack/poop", {"email": "poop2@poop.com"}, (res, data) => {
+        test.equal(res.statusCode, 200);
+        test.deepEqual(data, { email: "poop2@poop.com", slack: "poop" });
+
+        mockGET("/alias/email/poop@poop.com", (res, data) => {
+          test.equal(res.statusCode, 404);
+
+          mockGET("/alias/email/poop2@poop.com", (res, data) => {
+            test.equal(res.statusCode, 200);
+            test.deepEqual(data, { email: "poop2@poop.com", slack: "poop" });
+
+            test.done();
+          });
+        });
+      });
+    });
+  },
   "POST, PUT existing value": test => {
     test.expect(7);
 

--- a/tests/test-routes.js
+++ b/tests/test-routes.js
@@ -276,13 +276,13 @@ exports["/alias/`key`/`value`"] = {
 
     let data = {
       deepish: {cheggit: "", num: 0, bool: false},
-      email: "5@mail.com"
+      email: "325@mail.com"
     };
     mockPOST("/alias/bye/5", data, (res, data) => {
       test.equal(res.statusCode, 200);
       test.deepEqual(data, {
         bye: 5,
-        email: "5@mail.com",
+        email: "325@mail.com",
         deepish: {num: 0, bool: false}
       });
       test.done();
@@ -291,32 +291,32 @@ exports["/alias/`key`/`value`"] = {
   "POST, PUT with null values": test => {
     test.expect(2);
 
-    let data = {cheggit: null, email: "5@mail.com"};
+    let data = {cheggit: null, email: "538@mail.com"};
     mockPOST("/alias/bye/6", data, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {bye: 6, email: "5@mail.com"});
+      test.deepEqual(data, {bye: 6, email: "538@mail.com"});
       test.done();
     });
   },
   "POST, PUT with deep null values": test => {
     test.expect(2);
 
-    let data = {deepish: {cheggit: null}, email: "5@mail.com"};
+    let data = {deepish: {cheggit: null}, email: "0935@mail.com"};
     mockPOST("/alias/bye/7", data, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {bye: 7, email: "5@mail.com", deepish: {}});
+      test.deepEqual(data, {bye: 7, email: "0935@mail.com", deepish: {}});
       test.done();
     });
   },
   "POST, PUT new value": test => {
     test.expect(7);
 
-    mockPOST("/alias/bye/2", {cheggit: "yo", email: "5@mail.com"}, (
+    mockPOST("/alias/bye/2", {cheggit: "yo", email: "745@mail.com"}, (
       res,
       data
     ) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {bye: 2, cheggit: "yo", email: "5@mail.com"});
+      test.deepEqual(data, {bye: 2, cheggit: "yo", email: "745@mail.com"});
 
       mockGET("/alias/bye/2/history/", (res, data) => {
         test.equal(res.statusCode, 200);
@@ -328,7 +328,7 @@ exports["/alias/`key`/`value`"] = {
           {created: true, cur: "yo", author: "mock-post"}
         ]);
         test.deepEqual(data["email"].map(o => _.omit(o, "date")), [
-          {created: true, cur: "5@mail.com", author: "mock-post"}
+          {created: true, cur: "745@mail.com", author: "mock-post"}
         ]);
         test.done();
       });


### PR DESCRIPTION
Currently https://production--who-is-who.int.clever.com/list/email/ben.rollin@clever.com return objects.  It should return only one.  The happen because cleverbook created a ben.rollin@clever.com object by posting to `/alias/email/ben.rollin@clever.com`, while coffee-matched created a ben.rollin@clever.com object by posting to `/alias/slack/brollin`.  This inadvertently created two brollin objects.

This PR add a fix to make sure that doesn't happen again as well as a unit test to detect regressions.

TODO:
- [ ] Go into DB and remove the rogue brollin object
