### PR TITLE
Adds script to compare users with Google FTE group, mark as active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dynamo-local
 *~
 \#*\#
 .\#*
+
+# Token used for Google user sync
+token.json

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ test: lint
 lint:
 	./node_modules/.bin/eslint $(JS_FILES)
 
+sync:
+	node ./scripts/sync-users.js
+
 format:
 	./node_modules/.bin/prettier --bracket-spacing false --write $(JS_FILES)
 	./node_modules/.bin/eslint --fix $(JS_FILES)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "eslint": "^3.10.2",
+    "googleapis": "^19.0.0",
     "node-mocks-http": "^1.5.4",
     "nodeunit": "^0.11.0",
     "prettier": "^0.18.0"

--- a/scripts/sync-users.js
+++ b/scripts/sync-users.js
@@ -1,0 +1,150 @@
+const fs = require("fs");
+const readline = require("readline");
+const google = require("googleapis");
+const googleAuth = require("google-auth-library");
+const exec = require("child_process").exec;
+
+// Heavily inspired by https://developers.google.com/admin-sdk/directory/v1/quickstart/nodejs
+
+const SCOPES = ["https://www.googleapis.com/auth/admin.directory.user"];
+const TOKEN_DIR = ".";
+const TOKEN_PATH = "token.json";
+
+let endpoint = "https://dynamodb.us-west-1.amazonaws.com/";
+let region = "us-west-1";
+let accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+let secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+
+const storage = require("./../storage/dynamodb")(
+  endpoint,
+  region,
+  accessKeyId,
+  secretAccessKey,
+  "",
+  5
+);
+const db = require("./../db")(storage);
+
+const cmd = "ark secrets read production.who-is-who google-client-key --no-upgrade";
+
+exec(cmd, function(err, content) {
+  if (err) {
+    console.log("Error reading secret: " + err);
+    return;
+  }
+  authorize(JSON.parse(content), listUsers);
+});
+
+function authorize(credentials, callback) {
+  const clientSecret = credentials.installed.client_secret;
+  const clientId = credentials.installed.client_id;
+  const redirectUrl = credentials.installed.redirect_uris[0];
+  const auth = new googleAuth();
+  const oauth2Client = new auth.OAuth2(clientId, clientSecret, redirectUrl);
+
+  // Check if we have previously stored a token.
+  fs.readFile(TOKEN_PATH, function(err, token) {
+    if (err) {
+      console.log("Getting new token");
+      getNewToken(oauth2Client, callback);
+    } else {
+      oauth2Client.credentials = JSON.parse(token);
+      callback(oauth2Client);
+    }
+  });
+}
+
+function getNewToken(oauth2Client, callback) {
+  const authUrl = oauth2Client.generateAuthUrl({
+    access_type: "offline",
+    scope: SCOPES
+  });
+  console.log("Authorize this app by visiting this url: ", authUrl);
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+  rl.question("Enter the code from that page here: ", function(code) {
+    rl.close();
+    oauth2Client.getToken(code, function(err, token) {
+      if (err) {
+        console.log("Error while trying to retrieve access token", err);
+        return;
+      }
+      oauth2Client.credentials = token;
+      storeToken(token);
+      callback(oauth2Client);
+    });
+  });
+}
+
+function storeToken(token) {
+  try {
+    fs.mkdirSync(TOKEN_DIR);
+  } catch (err) {
+    if (err.code != "EEXIST") {
+      throw err;
+    }
+  }
+  fs.writeFile(TOKEN_PATH, JSON.stringify(token));
+  console.log("Token stored to " + TOKEN_PATH);
+}
+
+function listUsers(auth) {
+  const service = google.admin("directory_v1");
+  service.users.list({
+    auth: auth,
+    customer: "my_customer",
+    maxResults: 200,
+    orderBy: "email"
+  }, (err, response) => {
+    if (err) {
+      console.log("The API returned an error: " + err);
+      return;
+    }
+    const users = response.users;
+    if (users.length == 0) {
+      console.log("No users in the domain.");
+    } else {
+      db.all((err, data) => {
+        const googleEmails = users.filter(x => x.orgUnitPath == "/FTEs").map(u => u.primaryEmail);
+        let activeWhoIsWho = data.filter(u => u.active).map(u => u.email);
+        let inSync = true;
+        for (const googleEmail of googleEmails) {
+          const whoIsWho = data.filter(u => u.email == googleEmail);
+          if (whoIsWho.length != 1) {
+            console.log("Missing who is who for: " + googleEmail);
+            return;
+          } else {
+            const employee = whoIsWho[0];
+            if (employee.active) {
+              activeWhoIsWho = activeWhoIsWho.filter(email => email !== googleEmail);
+            } else {
+              inSync = false;
+              console.log("Not marked active, should be: " + googleEmail);
+              employee.active = true;
+              db.put("sync-users-script", "email", employee.email, employee, (err) => {
+                if (err) {
+                  console.log("Error updating user (" + employee.email + "): " + err);
+                }
+              });
+            }
+          }
+        }
+        for (const employee of activeWhoIsWho) {
+          inSync = false;
+          console.log("Marked active, should not be: " + employee);
+          employee.active = false;
+          db.put("sync-users-script", "email", employee.email, employee, (err) => {
+            if (err) {
+              console.log("Error updating user (" + employee.email + "): " + err);
+            }
+          });
+        }
+        if (inSync) {
+          console.log("You're in sync! Bye bye bye.");
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
**Jira:**
[SEC-488](https://clever.atlassian.net/browse/SEC-488)

**Overview:**
This change adds a script and a `make` target to sync `who-is-who` users with our Google G Suite directory.

It finds/fixes three conditions:

1) Google users not in who-is-who (error condition - exits).
2) Google users who are not marked `active` in `who-is-who` (updates)
3) Non-google users who are marked `active` in `who-is-who` (updates)

I'm not 100% this belongs here - alternatively I could move to the infra repo if it makes more sense there.

**Testing:**
I've run this with only my `who-is-who` account targeted, and it appears to write the `active` property correctly.

**Roll Out:**
As soon as a I get a +1, I'll run this for all users. I'm planning on using this to automate some aspects of our terraform setup in a future PR.
