### PR TITLE
Adds 'active' field to go-client, for who-is-who-syncer

### DIFF
--- a/go-client/client.go
+++ b/go-client/client.go
@@ -28,6 +28,7 @@ type User struct {
 	SlackID   string `json:"slack_id"`         // Slack
 	AWS       string `json:"aws"`              // first initial + last name
 	Github    string `json:"github,omitempty"` // Github
+	Active    bool   `json:"active"`           // Is user currently at Clever
 }
 
 // GetUserList makes a call to /list and returns all users.


### PR DESCRIPTION
I'd like to have our who-is-who-syncer mark the `active` field correctly (and deprecate the `make sync` task here). This should allow us to write that field.