### PR TITLE
Add retries to go client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-.PHONY: all test lint format run
+.PHONY: all test lint format run go-client
 SHELL := /bin/bash
 JS_FILES := $(shell find . -name "*.js" -not -path "./node_modules/*")
 
 all: test lint
 
-test: lint
+go-client:
+	go get -d -t github.com/Clever/who-is-who/go-client # fetch deps
+	go build go-client/client.go # ensures go client compiles
+	go test github.com/Clever/who-is-who/go-client # run tests
+
+test: go-client lint
 	@./tests/run_integration_tests.sh
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-.PHONY: all test lint format run go-client
+.PHONY: all test lint format run build-client
 SHELL := /bin/bash
 JS_FILES := $(shell find . -name "*.js" -not -path "./node_modules/*")
 
 all: test lint
 
-go-client:
+build-client:
 	go get -d -t github.com/Clever/who-is-who/go-client # fetch deps
 	go build go-client/client.go # ensures go client compiles
 	go test github.com/Clever/who-is-who/go-client # run tests
 
-test: go-client lint
+test: build-client lint
 	@./tests/run_integration_tests.sh
 
 lint:

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,14 @@
 machine:
   post:
   - cd $HOME && git clone --depth 1 -v git@github.com:clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+  - $HOME/ci-scripts/circleci/golang-install 1.9.1
   node:
     version: 8
   services:
   - docker
+checkout:
+  post:
+  - $HOME/ci-scripts/circleci/golang-move-project
 test:
   override:
   - npm install
@@ -25,3 +29,5 @@ deployment:
     - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
     - $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME
     branch: /^(?!master$).*$/
+general:
+  build_dir: ../.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME

--- a/go-client/client.go
+++ b/go-client/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
 // Client represents the API client. It holds the endpoint the server is expected to be
@@ -33,7 +35,7 @@ type User struct {
 
 // GetUserList makes a call to /list and returns all users.
 func (c Client) GetUserList() ([]User, error) {
-	resp, err := http.Get(c.endpoint + "/list")
+	resp, err := retryablehttp.Get(c.endpoint + "/list")
 	if err != nil {
 		return []User{}, fmt.Errorf("list users call failed => {%s}", err)
 	}
@@ -55,10 +57,10 @@ func (c Client) UpsertUser(author string, userInfo User) (User, error) {
 	if err != nil {
 		return User{}, fmt.Errorf("json marshaling failed => {%s}", err)
 	}
-	userInfoBuffer := bytes.NewBuffer(userInfoJson)
+	userInfoReader := bytes.NewReader(userInfoJson)
 
-	httpClient := &http.Client{}
-	req, err := http.NewRequest("PUT", c.endpoint+fmt.Sprintf("/alias/email/%s", email), userInfoBuffer)
+	httpClient := retryablehttp.NewClient()
+	req, err := retryablehttp.NewRequest("PUT", c.endpoint+fmt.Sprintf("/alias/email/%s", email), userInfoReader)
 	req.Header.Add("X-WIW-Author", author)
 	req.Header.Add("Content-Type", "application/json")
 
@@ -73,7 +75,7 @@ func (c Client) UpsertUser(author string, userInfo User) (User, error) {
 
 // UserByAWS finds a user based on their AWS username.
 func (c Client) UserByAWS(username string) (User, error) {
-	resp, err := http.Get(c.endpoint + fmt.Sprintf("/alias/aws/%s", username))
+	resp, err := retryablehttp.Get(c.endpoint + fmt.Sprintf("/alias/aws/%s", username))
 	if err != nil {
 		return User{}, fmt.Errorf("aws alias match call failed => {%s}", err)
 	}
@@ -83,7 +85,7 @@ func (c Client) UserByAWS(username string) (User, error) {
 
 // UserByGithub finds a user based on their Github username.
 func (c Client) UserByGithub(username string) (User, error) {
-	resp, err := http.Get(c.endpoint + fmt.Sprintf("/alias/github/%s", username))
+	resp, err := retryablehttp.Get(c.endpoint + fmt.Sprintf("/alias/github/%s", username))
 	if err != nil {
 		return User{}, fmt.Errorf("aws alias match call failed => {%s}", err)
 	}
@@ -93,7 +95,7 @@ func (c Client) UserByGithub(username string) (User, error) {
 
 // UserBySlack finds a user based on their Slack username.
 func (c Client) UserBySlack(username string) (User, error) {
-	resp, err := http.Get(c.endpoint + fmt.Sprintf("/alias/slack/%s", username))
+	resp, err := retryablehttp.Get(c.endpoint + fmt.Sprintf("/alias/slack/%s", username))
 	if err != nil {
 		return User{}, fmt.Errorf("slack alias match call failed => {%s}", err)
 	}
@@ -102,7 +104,7 @@ func (c Client) UserBySlack(username string) (User, error) {
 
 // UserByEmail finds a user based on their email.
 func (c Client) UserByEmail(email string) (User, error) {
-	resp, err := http.Get(c.endpoint + fmt.Sprintf("/alias/email/%s", email))
+	resp, err := retryablehttp.Get(c.endpoint + fmt.Sprintf("/alias/email/%s", email))
 	if err != nil {
 		return User{}, fmt.Errorf("email match call failed => {%s}", err)
 	}


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/INFRA-2749

**Overview:**
Previously, the Go client would sometimes fail an HTTP call (likely due to load on Dynamo backend). This adds retries to the client.

**Testing:**
Added tests to ensure the client builds. haven't yet tested the behavior but plan to enable this in Dapple.

**Roll Out:**
Merge here, then enable in who-is-who consumers
