### PR TITLE
Enforce type for `active` field

### DIFF
--- a/db.js
+++ b/db.js
@@ -165,7 +165,7 @@ module.exports = function(storage) {
 
         // Before creating a new object, try to find pre-existing object using email prop.
         // Should be effective since all new objects must have an email prop.
-        if(obj == null && key !== "email") {
+        if (obj == null && key !== "email") {
           body = _.set(body, key, val); // Here so key/val pair isn't lost
 
           return this.put(author, "email", body["email"], body, cb);
@@ -175,7 +175,9 @@ module.exports = function(storage) {
         let cur = _.defaultsDeep({}, body, prev);
         cur = removeEmptyValues(cur); // Don't save empty values
 
-        if(key === "email") { cur.email = val; }
+        if (key === "email") {
+          cur.email = val;
+        }
 
         if (!cur.email) {
           return cb(UserError("Can't save.  No email address found."));

--- a/db.js
+++ b/db.js
@@ -158,6 +158,11 @@ module.exports = function(storage) {
     put(author, key, val, body, cb) {
       val = parseIntIfNeeded(val);
 
+      // Validate field types
+      if (body && body.active && typeof body.active != "boolean") {
+        return cb(UserError("'active' field must be a boolean"));
+      }
+
       this.one(key, val, (err, obj) => {
         if (err) {
           return cb(err);

--- a/tests/test-routes.js
+++ b/tests/test-routes.js
@@ -367,17 +367,25 @@ exports["/alias/`key`/`value`"] = {
       test.equal(res.statusCode, 200);
       test.deepEqual(data, {cheggit: "yo", email: "peep@peep.com"});
 
-
-      mockPOST("/alias/slack/peep", {orto: "next", "email": "peep@peep.com"}, (res, data) => {
+      mockPOST("/alias/slack/peep", {orto: "next", email: "peep@peep.com"}, (
+        res,
+        data
+      ) => {
         test.equal(res.statusCode, 200);
         test.deepEqual(data, {
-          cheggit: "yo", orto: "next", email: "peep@peep.com", slack: "peep"
+          cheggit: "yo",
+          orto: "next",
+          email: "peep@peep.com",
+          slack: "peep"
         });
 
         mockGET("/alias/email/peep@peep.com", (res, data) => {
           test.equal(res.statusCode, 200);
           test.deepEqual(data, {
-            cheggit: "yo", orto: "next", email: "peep@peep.com", slack: "peep"
+            cheggit: "yo",
+            orto: "next",
+            email: "peep@peep.com",
+            slack: "peep"
           });
 
           mockGET("/alias/email/peep@peep.com/history/", (res, data) => {
@@ -407,9 +415,9 @@ exports["/alias/`key`/`value`"] = {
       test.equal(res.statusCode, 200);
       test.deepEqual(data, {slack: "poop", email: "poop@poop.com"});
 
-      mockPOST("/alias/slack/poop", {"email": "poop2@poop.com"}, (res, data) => {
+      mockPOST("/alias/slack/poop", {email: "poop2@poop.com"}, (res, data) => {
         test.equal(res.statusCode, 200);
-        test.deepEqual(data, { email: "poop2@poop.com", slack: "poop" });
+        test.deepEqual(data, {email: "poop2@poop.com", slack: "poop"});
 
         mockGET("/alias/email/poop@poop.com", (res, data) => {
           test.equal(res.statusCode, 404);
@@ -417,7 +425,7 @@ exports["/alias/`key`/`value`"] = {
 
           mockGET("/alias/email/poop2@poop.com", (res, data) => {
             test.equal(res.statusCode, 200);
-            test.deepEqual(data, { email: "poop2@poop.com", slack: "poop" });
+            test.deepEqual(data, {email: "poop2@poop.com", slack: "poop"});
 
             test.done();
           });


### PR DESCRIPTION
We've had a few issues locally where the Go client complained due to incorrect types. Specifically this has happened for the `active` field. This change requires `active` to be a `boolean`.

```
~/g/s/g/C/who-is-who ❯❯❯ http localhost:8081/alias/email/<redacted>@clever.com X-WIW-Author:nathan-leiby-local-httpie active=false
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 51
Content-Type: application/json; charset=utf-8
Date: Tue, 05 Jun 2018 19:41:15 GMT
ETag: W/"33-eXvrS2FY98OOoQsvkar2HCAs81Y"
X-Powered-By: Express

{
    "error": "Error: 'active' field must be a boolean"
}

~/g/s/g/C/who-is-who ❮❮❮ http localhost:8081/alias/email/<redacted>@clever.com X-WIW-Author:nathan-leiby-local-httpie active:=false
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 175
Content-Type: application/json; charset=utf-8
Date: Tue, 05 Jun 2018 19:41:51 GMT
ETag: W/"af-MUVd8qLbWvgOYT+Ulu4oMPYvj+k"
X-Powered-By: Express

{
    "active": false,
    ...
}
```

--

note: the 1st commit here is just a `make format`, which is automated