### PR TITLE
Update prettier

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,3 +21,5 @@ env:
   node: true
   mocha: true
 extends: 'eslint:recommended'
+parserOptions:
+  ecmaVersion: 2017

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,1 @@
+"@clever/prettier-config"

--- a/db.js
+++ b/db.js
@@ -18,10 +18,12 @@ function parseIntIfNeeded(n) {
 
 function toPaths(obj) {
   let paths = {};
-  let node, nodes = [{path: "", obj: obj}];
+  let node,
+    nodes = [{ path: "", obj: obj }];
 
   while ((node = nodes.pop()) != undefined) {
-    let obj = node.obj, path = node.path;
+    let obj = node.obj,
+      path = node.path;
 
     if (!_.isPlainObject(obj)) {
       paths[path] = obj;
@@ -30,10 +32,10 @@ function toPaths(obj) {
       paths[path] = {};
     } // Empty object means path contains a sub object
 
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj).forEach((key) => {
       let next = {
         path: !path ? key : path + "." + key,
-        obj: obj[key]
+        obj: obj[key],
       };
       nodes.push(next);
     });
@@ -49,16 +51,16 @@ function generateDiffs(author, prev, cur) {
   let curPaths = toPaths(cur);
 
   // Find deleted paths
-  Object.keys(prevPaths).forEach(path => {
+  Object.keys(prevPaths).forEach((path) => {
     if (path in curPaths) {
       return;
     }
 
-    diffs[path] = {deleted: true, prev: prevPaths[path], author: author};
+    diffs[path] = { deleted: true, prev: prevPaths[path], author: author };
   });
 
   // Find changed and created paths
-  Object.keys(curPaths).forEach(path => {
+  Object.keys(curPaths).forEach((path) => {
     let prev = prevPaths[path];
     let cur = curPaths[path];
 
@@ -67,9 +69,9 @@ function generateDiffs(author, prev, cur) {
     }
 
     if (path in prevPaths) {
-      diffs[path] = {prev: prev, cur: cur};
+      diffs[path] = { prev: prev, cur: cur };
     } else {
-      diffs[path] = {created: true, cur: cur};
+      diffs[path] = { created: true, cur: cur };
     }
     diffs[path].author = author;
   });
@@ -80,9 +82,10 @@ function generateDiffs(author, prev, cur) {
 function removeEmptyValues(obj) {
   obj = _.cloneDeep(obj);
 
-  let node, nodes = [obj];
+  let node,
+    nodes = [obj];
   while ((node = nodes.pop()) != undefined) {
-    Object.keys(node).forEach(key => {
+    Object.keys(node).forEach((key) => {
       if (node[key] === "" || _.isNil(node[key])) {
         delete node[key];
       }
@@ -94,7 +97,7 @@ function removeEmptyValues(obj) {
   return obj;
 }
 
-module.exports = function(storage) {
+module.exports = function (storage) {
   return {
     all(cb) {
       storage.all(cb);
@@ -139,7 +142,7 @@ module.exports = function(storage) {
           }
 
           let hist = {};
-          diffs.forEach(diff => {
+          diffs.forEach((diff) => {
             let d = _.omit(diff, "path");
 
             hist[diff.path] = hist[diff.path] || [];
@@ -147,7 +150,7 @@ module.exports = function(storage) {
             hist[diff.path].push(d);
           });
 
-          Object.keys(hist).forEach(key => {
+          Object.keys(hist).forEach((key) => {
             hist[key].sort((a, b) => b.date - a.date);
           });
 
@@ -165,28 +168,30 @@ module.exports = function(storage) {
 
         // Before creating a new object, try to find pre-existing object using email prop.
         // Should be effective since all new objects must have an email prop.
-        if(obj == null && key !== "email") {
+        if (obj == null && key !== "email") {
           body = _.set(body, key, val); // Here so key/val pair isn't lost
 
           return this.put(author, "email", body["email"], body, cb);
         }
 
-        let prev = obj || {_whoid: uuid()};
+        let prev = obj || { _whoid: uuid() };
         let cur = _.defaultsDeep({}, body, prev);
         cur = removeEmptyValues(cur); // Don't save empty values
 
-        if(key === "email") { cur.email = val; }
+        if (key === "email") {
+          cur.email = val;
+        }
 
         if (!cur.email) {
           return cb(UserError("Can't save.  No email address found."));
         }
-        if (Object.keys(cur).some(k => k.indexOf(".") !== -1)) {
+        if (Object.keys(cur).some((k) => k.indexOf(".") !== -1)) {
           return cb(UserError("Key with dots ('.') aren't supported"));
         }
 
         let diffs = generateDiffs(author, prev, cur);
         storage.put(cur, diffs, cb);
       });
-    }
+    },
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,6 +170,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@clever/prettier-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clever/prettier-config/-/prettier-config-1.0.0.tgz",
+      "integrity": "sha512-kWQUUXgyP+KvjXvjrK+FOD+RIXlcP3sFmArXDowgHtMolv+COMkdlUsgu5/+x1fNymLa+JmWVnXk2P8STllSVA==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -285,12 +291,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "ast-types": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.4.tgz",
-      "integrity": "sha1-QQ0fgYkK644KOGIVWLpYaa5TyRs=",
-      "dev": true
-    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -347,12 +347,6 @@
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.2"
       }
-    },
-    "babylon": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz",
-      "integrity": "sha1-umXPoagOF1mw6J+1YuJ9zK5wNI4=",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -631,12 +625,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "combined-stream": {
@@ -1329,31 +1317,6 @@
         "write": "^0.2.1"
       }
     },
-    "flow-parser": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.38.0.tgz",
-      "integrity": "sha1-pjHEYXDFtCQA2QWnXPyDzo2ylCQ=",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.8.18",
-        "colors": ">=0.6.2",
-        "minimist": ">=0.2.0"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.8.18",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.18.tgz",
-          "integrity": "sha1-yLmFdImOiRTp2N50uUdWSp/pKa8=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "foreground-child": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
@@ -1420,12 +1383,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "getpass": {
@@ -1876,28 +1833,6 @@
         "handlebars": "^4.1.2"
       }
     },
-    "jest-matcher-utils": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-18.1.0.tgz",
-      "integrity": "sha1-GsRlGVXuKmDO8ef8yYzf13PA+TI=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "pretty-format": "^18.1.0"
-      }
-    },
-    "jest-validate": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-18.2.0.tgz",
-      "integrity": "sha1-Afk6x48jkBz5iJgI4ru5Mf/FjYY=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.1",
-        "jest-matcher-utils": "^18.1.0",
-        "leven": "^2.0.0",
-        "pretty-format": "^18.1.0"
-      }
-    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -2029,12 +1964,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
       "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true
-    },
-    "leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
       "dev": true
     },
     "levn": {
@@ -2592,70 +2521,10 @@
       "dev": true
     },
     "prettier": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-0.18.0.tgz",
-      "integrity": "sha1-nvWRjVOlaUbLyQwhO+DbCwqupzw=",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.9.4",
-        "babel-code-frame": "6.22.0",
-        "babylon": "6.15.0",
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "flow-parser": "0.38.0",
-        "get-stdin": "5.0.1",
-        "glob": "7.1.1",
-        "jest-validate": "18.2.0",
-        "minimist": "1.2.0"
-      },
-      "dependencies": {
-        "babel-code-frame": {
-          "version": "6.22.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "pretty-format": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-18.1.0.tgz",
-      "integrity": "sha1-+2Wob3p/kZSWPu6RhlwbzxA54oQ=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^2.2.1"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "uuid": "^2.0.1"
   },
   "devDependencies": {
+    "@clever/prettier-config": "1.0.0",
     "eslint": "^3.10.2",
     "googleapis": "^19.0.0",
     "node-mocks-http": "^1.5.4",
     "nodeunit": "^0.11.0",
-    "prettier": "^0.18.0"
+    "prettier": "2.1.2"
   }
 }

--- a/router.js
+++ b/router.js
@@ -15,13 +15,13 @@ function genericResponder(res) {
   return (err, data) => {
     if (err) {
       if (err.isUserError) {
-        return res.status(400).json({error: err.toString()});
+        return res.status(400).json({ error: err.toString() });
       }
 
-      return res.status(500).json({error: err.toString()});
+      return res.status(500).json({ error: err.toString() });
     }
     if (data == null) {
-      return res.status(404).json({error: "not-found"});
+      return res.status(404).json({ error: "not-found" });
     }
     if (data != null && _.isEmpty(data)) {
       return res.status(404).json(data);
@@ -31,22 +31,22 @@ function genericResponder(res) {
   };
 }
 
-module.exports = function(db) {
+module.exports = function (db) {
   return bee.route({
     "/health": (req, res) => {
-      res.json({ok: true});
+      res.json({ ok: true });
     },
     "/alias /all /list": {
       GET: (req, res) => {
         db.all(genericResponder(res));
-      }
+      },
     },
     "/alias/`key` /list/`key`": {
       GET: (req, res) => {
         let key = req.params["key"];
 
         db.has(key, genericResponder(res));
-      }
+      },
     },
     "/alias/`key`/`value`": {
       GET: (req, res) => {
@@ -58,14 +58,14 @@ module.exports = function(db) {
       "POST PUT": (req, res) => {
         let author = req.headers["x-wiw-author"];
         if (!author) {
-          return res.status(400).json({error: "no X-WIW-Author header"});
+          return res.status(400).json({ error: "no X-WIW-Author header" });
         }
 
         let key = req.params["key"];
         let value = req.params["value"];
 
         db.put(author, key, value, req.body, genericResponder(res));
-      }
+      },
     },
     "/list/`key`/`value`": {
       GET: (req, res) => {
@@ -73,7 +73,7 @@ module.exports = function(db) {
         let value = req.params["value"];
 
         db.by(key, value, genericResponder(res));
-      }
+      },
     },
     "/alias/`key`/`value`/data/`path...`": {
       GET: (req, res) => {
@@ -82,17 +82,17 @@ module.exports = function(db) {
 
         db.one(key, value, (err, data) => {
           if (err) {
-            return res.status(500).json({error: err.toString()});
+            return res.status(500).json({ error: err.toString() });
           }
           if (!data) {
-            return res.status(404).json({error: "not-found"});
+            return res.status(404).json({ error: "not-found" });
           }
 
           let path = req.params["path"].split("/");
           data = _.get(omitId(data), path);
 
           if (data == null) {
-            return res.status(404).json({error: "not-found"});
+            return res.status(404).json({ error: "not-found" });
           }
 
           return res.json(data);
@@ -101,7 +101,7 @@ module.exports = function(db) {
       "POST PUT": (req, res) => {
         let author = req.headers["x-wiw-author"];
         if (!author) {
-          return res.status(400).json({error: "no X-WIW-Author header"});
+          return res.status(400).json({ error: "no X-WIW-Author header" });
         }
 
         let key = req.params["key"];
@@ -111,7 +111,7 @@ module.exports = function(db) {
         let data = _.set({}, path, req.body);
 
         db.put(author, key, value, data, genericResponder(res));
-      }
+      },
     },
     "/list/`key`/`value`/data/`path...`": {
       GET: (req, res) => {
@@ -120,7 +120,7 @@ module.exports = function(db) {
 
         db.by(key, value, (err, data) => {
           if (err) {
-            return res.status(500).json({error: err.toString()});
+            return res.status(500).json({ error: err.toString() });
           }
           if (_.isEmpty(data)) {
             return res.status(404).json(data);
@@ -131,7 +131,7 @@ module.exports = function(db) {
           let path = req.params["path"].replace("/", ".");
           return res.json(_.flatten(_.map(data, path)));
         });
-      }
+      },
     },
     "/alias/`key`/`value`/history/`path...`": {
       GET: (req, res) => {
@@ -140,7 +140,7 @@ module.exports = function(db) {
         let path = req.params["path"].replace("/", ".");
 
         db.history(key, value, path, genericResponder(res));
-      }
-    }
+      },
+    },
   });
 };

--- a/server.js
+++ b/server.js
@@ -7,8 +7,7 @@ const log = new kv.logger("who-is-who");
 
 let port = process.env.PORT || "80";
 
-let endpoint = process.env.AWS_DYNAMO_ENDPOINT ||
-  "https://dynamodb.us-west-1.amazonaws.com/";
+let endpoint = process.env.AWS_DYNAMO_ENDPOINT || "https://dynamodb.us-west-1.amazonaws.com/";
 let region = process.env.AWS_DYNAMO_REGION || "us-west-1";
 let accessKeyId = process.env.AWS_ACCESS_KEY_ID;
 let secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
@@ -21,16 +20,16 @@ const storage = require("./storage/dynamodb")(
   accessKeyId,
   secretAccessKey,
   tableNameSuffix,
-  dynamoReadWriteCapacity
+  dynamoReadWriteCapacity,
 );
 const db = require("./db")(storage);
 const router = require("./router")(db);
 
 let app = express();
 
-app.use(kv.middleware({source: "who-is-who"}));
+app.use(kv.middleware({ source: "who-is-who" }));
 app.use(bodyParser.json());
 
 app.use(router).listen(port);
 
-log.infoD("server ready", {"listening on": port});
+log.infoD("server ready", { "listening on": port });

--- a/tests/test-routes.js
+++ b/tests/test-routes.js
@@ -6,26 +6,19 @@ const mocks = require("node-mocks-http");
 const async = require("async");
 
 let endpoint = process.env.AWS_DYNAMO_ENDPOINT;
-let storage = require("../storage/dynamodb")(
-  endpoint,
-  "us-west-1",
-  "test",
-  "test",
-  "test",
-  1
-);
+let storage = require("../storage/dynamodb")(endpoint, "us-west-1", "test", "test", "test", 1);
 
 const db = require("../db")(storage);
 const router = require("../router")(db);
 
 let mockData = [
-  {email: "1@mail.com", uniq: 1, hi: 1, a: "a", deep: {a: 1}},
-  {email: "2@mail.com", uniq: 2, hi: 1, a: "ab", deep: {b: 1}},
-  {email: "3@mail.com", uniq: 3, hi: 2, a: "abc", deep: {c: 1}},
-  {email: "4@mail.com", uniq: 4, bye: 1, a: "abcd", deeper: {d: {e: 1}}}
+  { email: "1@mail.com", uniq: 1, hi: 1, a: "a", deep: { a: 1 } },
+  { email: "2@mail.com", uniq: 2, hi: 1, a: "ab", deep: { b: 1 } },
+  { email: "3@mail.com", uniq: 3, hi: 2, a: "abc", deep: { c: 1 } },
+  { email: "4@mail.com", uniq: 4, bye: 1, a: "abcd", deeper: { d: { e: 1 } } },
 ];
 let dbPopulated = false;
-exports.setUp = function(done) {
+exports.setUp = function (done) {
   if (dbPopulated) {
     return done();
   }
@@ -33,23 +26,23 @@ exports.setUp = function(done) {
   async.each(
     mockData,
     (data, cb) => db.put("init", "email", data.email, data, cb),
-    err => {
+    (err) => {
       if (err) {
         throw err;
       }
 
       dbPopulated = true;
       done();
-    }
+    },
   );
 };
-exports.tearDown = function(done) {
+exports.tearDown = function (done) {
   done();
 };
 
 function mockSend(opt, cb) {
   let req = mocks.createRequest(opt);
-  let res = mocks.createResponse({eventEmitter: emitter});
+  let res = mocks.createResponse({ eventEmitter: emitter });
 
   res.on("end", () => {
     assert.ok(res._isJSON);
@@ -64,7 +57,7 @@ function mockSend(opt, cb) {
 }
 
 function mockGET(url, cb) {
-  return mockSend({url: url, method: "GET"}, cb);
+  return mockSend({ url: url, method: "GET" }, cb);
 }
 
 function mockPOST(url, body, cb) {
@@ -73,13 +66,13 @@ function mockPOST(url, body, cb) {
       url: url,
       body: body,
       method: "POST",
-      headers: {"X-WIW-Author": "mock-post"}
+      headers: { "X-WIW-Author": "mock-post" },
     },
-    cb
+    cb,
   );
 }
 
-exports["/alias, /all, /list"] = function(test) {
+exports["/alias, /all, /list"] = function (test) {
   test.expect(2);
 
   mockGET("/all", (res, data) => {
@@ -93,7 +86,7 @@ exports["/alias, /all, /list"] = function(test) {
 };
 
 exports["/alias/`key`, /list/`key`"] = {
-  "multi-match": test => {
+  "multi-match": (test) => {
     test.expect(2);
 
     mockGET("/alias/hi", (res, data) => {
@@ -102,7 +95,7 @@ exports["/alias/`key`, /list/`key`"] = {
       test.done();
     });
   },
-  "no pre-fix for deep keys": test => {
+  "no pre-fix for deep keys": (test) => {
     test.expect(2);
 
     mockGET("/list/de", (res, data) => {
@@ -111,7 +104,7 @@ exports["/alias/`key`, /list/`key`"] = {
       test.done();
     });
   },
-  "no pre-fix for values": test => {
+  "no pre-fix for values": (test) => {
     test.expect(2);
 
     mockGET("/alias/a/a", (res, data) => {
@@ -120,7 +113,7 @@ exports["/alias/`key`, /list/`key`"] = {
       test.done();
     });
   },
-  "deep key": test => {
+  "deep key": (test) => {
     test.expect(3);
 
     mockGET("/list/deep.a", (res, data) => {
@@ -130,7 +123,7 @@ exports["/alias/`key`, /list/`key`"] = {
       test.done();
     });
   },
-  "deeper key": test => {
+  "deeper key": (test) => {
     test.expect(3);
 
     mockGET("/alias/deeper.d.e", (res, data) => {
@@ -140,7 +133,7 @@ exports["/alias/`key`, /list/`key`"] = {
       test.done();
     });
   },
-  "no-matches": test => {
+  "no-matches": (test) => {
     test.expect(2);
 
     mockGET("/list/no_matches", (res, data) => {
@@ -148,11 +141,11 @@ exports["/alias/`key`, /list/`key`"] = {
       test.equal(data.length, 0);
       test.done();
     });
-  }
+  },
 };
 
 exports["/alias/`key`/`value`"] = {
-  uniq: test => {
+  uniq: (test) => {
     test.expect(2);
 
     mockGET("/alias/hi/2", (res, data) => {
@@ -161,16 +154,16 @@ exports["/alias/`key`/`value`"] = {
       test.done();
     });
   },
-  "/data/`path...` uniq": test => {
+  "/data/`path...` uniq": (test) => {
     test.expect(2);
 
     mockGET("/alias/hi/2/data/deep", (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {c: 1});
+      test.deepEqual(data, { c: 1 });
       test.done();
     });
   },
-  "multi-match error": test => {
+  "multi-match error": (test) => {
     test.expect(2);
 
     mockGET("/alias/hi/1", (res, data) => {
@@ -179,7 +172,7 @@ exports["/alias/`key`/`value`"] = {
       test.done();
     });
   },
-  "/data/`path...` multi-match error": test => {
+  "/data/`path...` multi-match error": (test) => {
     test.expect(2);
 
     mockGET("/alias/hi/1/data/deep", (res, data) => {
@@ -188,7 +181,7 @@ exports["/alias/`key`/`value`"] = {
       test.done();
     });
   },
-  "no-matches": test => {
+  "no-matches": (test) => {
     test.expect(2);
 
     mockGET("/alias/hi/3", (res, data) => {
@@ -197,7 +190,7 @@ exports["/alias/`key`/`value`"] = {
       test.done();
     });
   },
-  "/data/`path...` no-matches": test => {
+  "/data/`path...` no-matches": (test) => {
     test.expect(2);
 
     mockGET("/alias/hi/3/data/deep", (res, data) => {
@@ -206,14 +199,14 @@ exports["/alias/`key`/`value`"] = {
       test.done();
     });
   },
-  "POST, PUT with no author": test => {
+  "POST, PUT with no author": (test) => {
     test.expect(2);
 
     let opts = {
       url: "/alias/bye/2",
-      body: {cheggit: "yo", email: "5@mail.com"},
+      body: { cheggit: "yo", email: "5@mail.com" },
       method: "POST",
-      headers: {}
+      headers: {},
     };
     mockSend(opts, (res, data) => {
       test.equal(res.statusCode, 400);
@@ -221,14 +214,14 @@ exports["/alias/`key`/`value`"] = {
       test.done();
     });
   },
-  "POST, PUT with no author deep data": test => {
+  "POST, PUT with no author deep data": (test) => {
     test.expect(2);
 
     let opts = {
       url: "/alias/email/5@email.com/data/deep",
-      body: {cheggit: "yo"},
+      body: { cheggit: "yo" },
       method: "POST",
-      headers: {}
+      headers: {},
     };
     mockSend(opts, (res, data) => {
       test.equal(res.statusCode, 400);
@@ -236,14 +229,14 @@ exports["/alias/`key`/`value`"] = {
       test.done();
     });
   },
-  "POST, PUT with no email": test => {
+  "POST, PUT with no email": (test) => {
     test.expect(2);
 
     let opts = {
       url: "/alias/foo/bar",
-      body: {cheggit: "yo"},
+      body: { cheggit: "yo" },
       method: "POST",
-      headers: {}
+      headers: {},
     };
     mockSend(opts, (res, data) => {
       test.equal(res.statusCode, 400);
@@ -251,163 +244,172 @@ exports["/alias/`key`/`value`"] = {
       test.done();
     });
   },
-  "POST, PUT keys with dots": test => {
+  "POST, PUT keys with dots": (test) => {
     test.expect(2);
 
-    let data = {"cheg.git": "yo", email: "7@mail.com"};
+    let data = { "cheg.git": "yo", email: "7@mail.com" };
     mockPOST("/alias/bye/3", data, (res, data) => {
       test.equal(res.statusCode, 400);
       test.ok(data.error);
       test.done();
     });
   },
-  "POST, PUT with empty values": test => {
+  "POST, PUT with empty values": (test) => {
     test.expect(2);
 
-    let data = {cheggit: "", email: "5@mail.com", num: 0, bool: false};
+    let data = { cheggit: "", email: "5@mail.com", num: 0, bool: false };
     mockPOST("/alias/bye/4", data, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {bye: 4, email: "5@mail.com", num: 0, bool: false});
+      test.deepEqual(data, { bye: 4, email: "5@mail.com", num: 0, bool: false });
       test.done();
     });
   },
-  "POST, PUT with deep empty values": test => {
+  "POST, PUT with deep empty values": (test) => {
     test.expect(2);
 
     let data = {
-      deepish: {cheggit: "", num: 0, bool: false},
-      email: "325@mail.com"
+      deepish: { cheggit: "", num: 0, bool: false },
+      email: "325@mail.com",
     };
     mockPOST("/alias/bye/5", data, (res, data) => {
       test.equal(res.statusCode, 200);
       test.deepEqual(data, {
         bye: 5,
         email: "325@mail.com",
-        deepish: {num: 0, bool: false}
+        deepish: { num: 0, bool: false },
       });
       test.done();
     });
   },
-  "POST, PUT with null values": test => {
+  "POST, PUT with null values": (test) => {
     test.expect(2);
 
-    let data = {cheggit: null, email: "538@mail.com"};
+    let data = { cheggit: null, email: "538@mail.com" };
     mockPOST("/alias/bye/6", data, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {bye: 6, email: "538@mail.com"});
+      test.deepEqual(data, { bye: 6, email: "538@mail.com" });
       test.done();
     });
   },
-  "POST, PUT with deep null values": test => {
+  "POST, PUT with deep null values": (test) => {
     test.expect(2);
 
-    let data = {deepish: {cheggit: null}, email: "0935@mail.com"};
+    let data = { deepish: { cheggit: null }, email: "0935@mail.com" };
     mockPOST("/alias/bye/7", data, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {bye: 7, email: "0935@mail.com", deepish: {}});
+      test.deepEqual(data, { bye: 7, email: "0935@mail.com", deepish: {} });
       test.done();
     });
   },
-  "POST, PUT new value": test => {
+  "POST, PUT new value": (test) => {
     test.expect(7);
 
-    mockPOST("/alias/bye/2", {cheggit: "yo", email: "745@mail.com"}, (
-      res,
-      data
-    ) => {
+    mockPOST("/alias/bye/2", { cheggit: "yo", email: "745@mail.com" }, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {bye: 2, cheggit: "yo", email: "745@mail.com"});
+      test.deepEqual(data, { bye: 2, cheggit: "yo", email: "745@mail.com" });
 
       mockGET("/alias/bye/2/history/", (res, data) => {
         test.equal(res.statusCode, 200);
         test.equal(Object.keys(data).length, 3);
-        test.deepEqual(data["bye"].map(o => _.omit(o, "date")), [
-          {created: true, cur: 2, author: "mock-post"}
-        ]);
-        test.deepEqual(data["cheggit"].map(o => _.omit(o, "date")), [
-          {created: true, cur: "yo", author: "mock-post"}
-        ]);
-        test.deepEqual(data["email"].map(o => _.omit(o, "date")), [
-          {created: true, cur: "745@mail.com", author: "mock-post"}
-        ]);
+        test.deepEqual(
+          data["bye"].map((o) => _.omit(o, "date")),
+          [{ created: true, cur: 2, author: "mock-post" }],
+        );
+        test.deepEqual(
+          data["cheggit"].map((o) => _.omit(o, "date")),
+          [{ created: true, cur: "yo", author: "mock-post" }],
+        );
+        test.deepEqual(
+          data["email"].map((o) => _.omit(o, "date")),
+          [{ created: true, cur: "745@mail.com", author: "mock-post" }],
+        );
         test.done();
       });
     });
   },
-  "POST, PUT new value deep data": test => {
+  "POST, PUT new value deep data": (test) => {
     test.expect(7);
 
-    mockPOST("/alias/email/6@mail.com/data/greets", {cheggit: "yo"}, (
-      res,
-      data
-    ) => {
+    mockPOST("/alias/email/6@mail.com/data/greets", { cheggit: "yo" }, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {email: "6@mail.com", greets: {cheggit: "yo"}});
+      test.deepEqual(data, { email: "6@mail.com", greets: { cheggit: "yo" } });
 
       mockGET("/alias/email/6@mail.com/history/", (res, data) => {
         test.equal(res.statusCode, 200);
         test.equal(Object.keys(data).length, 3);
-        test.deepEqual(data["greets"].map(o => _.omit(o, "date")), [
-          {created: true, cur: {}, author: "mock-post"}
-        ]);
-        test.deepEqual(data["email"].map(o => _.omit(o, "date")), [
-          {created: true, cur: "6@mail.com", author: "mock-post"}
-        ]);
-        test.deepEqual(data["greets.cheggit"].map(o => _.omit(o, "date")), [
-          {created: true, cur: "yo", author: "mock-post"}
-        ]);
+        test.deepEqual(
+          data["greets"].map((o) => _.omit(o, "date")),
+          [{ created: true, cur: {}, author: "mock-post" }],
+        );
+        test.deepEqual(
+          data["email"].map((o) => _.omit(o, "date")),
+          [{ created: true, cur: "6@mail.com", author: "mock-post" }],
+        );
+        test.deepEqual(
+          data["greets.cheggit"].map((o) => _.omit(o, "date")),
+          [{ created: true, cur: "yo", author: "mock-post" }],
+        );
         test.done();
       });
     });
   },
-  "POST, PUT objects with the same email address are merged": test => {
+  "POST, PUT objects with the same email address are merged": (test) => {
     test.expect(11);
 
-    mockPOST("/alias/email/peep@peep.com", {cheggit: "yo"}, (res, data) => {
+    mockPOST("/alias/email/peep@peep.com", { cheggit: "yo" }, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {cheggit: "yo", email: "peep@peep.com"});
+      test.deepEqual(data, { cheggit: "yo", email: "peep@peep.com" });
 
-
-      mockPOST("/alias/slack/peep", {orto: "next", "email": "peep@peep.com"}, (res, data) => {
+      mockPOST("/alias/slack/peep", { orto: "next", email: "peep@peep.com" }, (res, data) => {
         test.equal(res.statusCode, 200);
         test.deepEqual(data, {
-          cheggit: "yo", orto: "next", email: "peep@peep.com", slack: "peep"
+          cheggit: "yo",
+          orto: "next",
+          email: "peep@peep.com",
+          slack: "peep",
         });
 
         mockGET("/alias/email/peep@peep.com", (res, data) => {
           test.equal(res.statusCode, 200);
           test.deepEqual(data, {
-            cheggit: "yo", orto: "next", email: "peep@peep.com", slack: "peep"
+            cheggit: "yo",
+            orto: "next",
+            email: "peep@peep.com",
+            slack: "peep",
           });
 
           mockGET("/alias/email/peep@peep.com/history/", (res, data) => {
             test.equal(Object.keys(data).length, 4);
-            test.deepEqual(data["orto"].map(o => _.omit(o, "date")), [
-              {created: true, cur: "next", author: "mock-post"}
-            ]);
-            test.deepEqual(data["cheggit"].map(o => _.omit(o, "date")), [
-              {created: true, cur: "yo", author: "mock-post"}
-            ]);
-            test.deepEqual(data["email"].map(o => _.omit(o, "date")), [
-              {created: true, cur: "peep@peep.com", author: "mock-post"}
-            ]);
-            test.deepEqual(data["slack"].map(o => _.omit(o, "date")), [
-              {created: true, cur: "peep", author: "mock-post"}
-            ]);
+            test.deepEqual(
+              data["orto"].map((o) => _.omit(o, "date")),
+              [{ created: true, cur: "next", author: "mock-post" }],
+            );
+            test.deepEqual(
+              data["cheggit"].map((o) => _.omit(o, "date")),
+              [{ created: true, cur: "yo", author: "mock-post" }],
+            );
+            test.deepEqual(
+              data["email"].map((o) => _.omit(o, "date")),
+              [{ created: true, cur: "peep@peep.com", author: "mock-post" }],
+            );
+            test.deepEqual(
+              data["slack"].map((o) => _.omit(o, "date")),
+              [{ created: true, cur: "peep", author: "mock-post" }],
+            );
             test.done();
           });
         });
       });
     });
   },
-  "POST, PUT editting email address works": test => {
+  "POST, PUT editting email address works": (test) => {
     test.expect(8);
 
-    mockPOST("/alias/email/poop@poop.com", {slack: "poop"}, (res, data) => {
+    mockPOST("/alias/email/poop@poop.com", { slack: "poop" }, (res, data) => {
       test.equal(res.statusCode, 200);
-      test.deepEqual(data, {slack: "poop", email: "poop@poop.com"});
+      test.deepEqual(data, { slack: "poop", email: "poop@poop.com" });
 
-      mockPOST("/alias/slack/poop", {"email": "poop2@poop.com"}, (res, data) => {
+      mockPOST("/alias/slack/poop", { email: "poop2@poop.com" }, (res, data) => {
         test.equal(res.statusCode, 200);
         test.deepEqual(data, { email: "poop2@poop.com", slack: "poop" });
 
@@ -425,28 +427,31 @@ exports["/alias/`key`/`value`"] = {
       });
     });
   },
-  "POST, PUT existing value": test => {
+  "POST, PUT existing value": (test) => {
     test.expect(7);
 
-    mockPOST("/alias/uniq/1", {hi: 2}, (res, data) => {
+    mockPOST("/alias/uniq/1", { hi: 2 }, (res, data) => {
       test.equal(res.statusCode, 200);
       test.deepEqual(data, {
         email: "1@mail.com",
         uniq: 1,
         hi: 2,
         a: "a",
-        deep: {a: 1}
+        deep: { a: 1 },
       });
 
       mockGET("/alias/uniq/1/history/hi", (res, data) => {
         test.equal(res.statusCode, 200);
         test.equal(Object.keys(data).length, 1);
-        test.deepEqual(data["hi"].map(o => _.omit(o, "date")), [
-          {prev: 1, cur: 2, author: "mock-post"},
-          {created: true, cur: 1, author: "init"}
-        ]);
+        test.deepEqual(
+          data["hi"].map((o) => _.omit(o, "date")),
+          [
+            { prev: 1, cur: 2, author: "mock-post" },
+            { created: true, cur: 1, author: "init" },
+          ],
+        );
 
-        mockPOST("/alias/uniq/1", {hi: 1}, (res, data) => {
+        mockPOST("/alias/uniq/1", { hi: 1 }, (res, data) => {
           test.equal(res.statusCode, 200);
           test.deepEqual(data, {
             // Reset mock data
@@ -454,35 +459,38 @@ exports["/alias/`key`/`value`"] = {
             uniq: 1,
             hi: 1,
             a: "a",
-            deep: {a: 1}
+            deep: { a: 1 },
           });
           test.done();
         });
       });
     });
   },
-  "POST, PUT existing value deep data": test => {
+  "POST, PUT existing value deep data": (test) => {
     test.expect(9);
 
-    mockPOST("/alias/uniq/1/data/deep", {a: 2}, (res, data) => {
+    mockPOST("/alias/uniq/1/data/deep", { a: 2 }, (res, data) => {
       test.equal(res.statusCode, 200);
       test.deepEqual(data, {
         email: "1@mail.com",
         uniq: 1,
         hi: 1,
-        deep: {a: 2},
-        a: "a"
+        deep: { a: 2 },
+        a: "a",
       });
 
       mockGET("/alias/uniq/1/history/deep/a", (res, data) => {
         test.equal(res.statusCode, 200);
         test.equal(Object.keys(data).length, 1);
-        test.deepEqual(data["deep.a"].map(o => _.omit(o, "date")), [
-          {prev: 1, cur: 2, author: "mock-post"},
-          {created: true, cur: 1, author: "init"}
-        ]);
+        test.deepEqual(
+          data["deep.a"].map((o) => _.omit(o, "date")),
+          [
+            { prev: 1, cur: 2, author: "mock-post" },
+            { created: true, cur: 1, author: "init" },
+          ],
+        );
 
-        mockPOST("/alias/uniq/1/data/deep", {a: 1}, (res, data) => {
+        mockPOST("/alias/uniq/1/data/deep", { a: 1 }, (res, data) => {
           test.equal(res.statusCode, 200);
           test.deepEqual(data, {
             // Reset mock data
@@ -490,7 +498,7 @@ exports["/alias/`key`/`value`"] = {
             uniq: 1,
             hi: 1,
             a: "a",
-            deep: {a: 1}
+            deep: { a: 1 },
           });
 
           mockGET("/alias/uniq/1/history/de", (res, data) => {
@@ -502,20 +510,14 @@ exports["/alias/`key`/`value`"] = {
       });
     });
   },
-  "POST, PUT deleting deep object": test => {
+  "POST, PUT deleting deep object": (test) => {
     test.expect(6);
 
-    mockPOST("/alias/email/8@email.com", {a: 2, b: 3, c: {d: 6}}, (
-      res,
-      data
-    ) => {
+    mockPOST("/alias/email/8@email.com", { a: 2, b: 3, c: { d: 6 } }, (res, data) => {
       test.equal(res.statusCode, 200);
       test.ok(data.c);
 
-      mockPOST("/alias/email/8@email.com", {a: 2, b: 3, c: null}, (
-        res,
-        data
-      ) => {
+      mockPOST("/alias/email/8@email.com", { a: 2, b: 3, c: null }, (res, data) => {
         test.equal(res.statusCode, 200);
         test.ok(!data.c);
 
@@ -527,11 +529,11 @@ exports["/alias/`key`/`value`"] = {
         });
       });
     });
-  }
+  },
 };
 
 exports["/list/`key`"] = {
-  "no vals": test => {
+  "no vals": (test) => {
     test.expect(2);
 
     mockGET("/list/nudting", (res, data) => {
@@ -540,30 +542,30 @@ exports["/list/`key`"] = {
       test.done();
     });
   },
-  "shallow key": test => {
+  "shallow key": (test) => {
     test.expect(3);
 
     mockGET("/list/hi", (res, data) => {
       test.equal(res.statusCode, 200);
       test.equal(data.length, 3);
-      test.deepEqual(data.map(d => d.uniq).sort(), [1, 2, 3]);
+      test.deepEqual(data.map((d) => d.uniq).sort(), [1, 2, 3]);
       test.done();
     });
   },
-  "deep key": test => {
+  "deep key": (test) => {
     test.expect(3);
 
     mockGET("/list/deep", (res, data) => {
       test.equal(res.statusCode, 200);
       test.equal(data.length, 3);
-      test.deepEqual(data.map(d => d.uniq).sort(), [1, 2, 3]);
+      test.deepEqual(data.map((d) => d.uniq).sort(), [1, 2, 3]);
       test.done();
     });
-  }
+  },
 };
 
 exports["/list/`key`/`value`"] = {
-  "no vals": test => {
+  "no vals": (test) => {
     test.expect(2);
 
     mockGET("/list/nudting/hello", (res, data) => {
@@ -572,17 +574,17 @@ exports["/list/`key`/`value`"] = {
       test.done();
     });
   },
-  "shallow key": test => {
+  "shallow key": (test) => {
     test.expect(3);
 
     mockGET("/list/hi/1", (res, data) => {
       test.equal(res.statusCode, 200);
       test.equal(data.length, 2);
-      test.deepEqual(data.map(d => d.uniq).sort(), [1, 2]);
+      test.deepEqual(data.map((d) => d.uniq).sort(), [1, 2]);
       test.done();
     });
   },
-  "single key": test => {
+  "single key": (test) => {
     test.expect(3);
 
     mockGET("/list/hi/2", (res, data) => {
@@ -591,7 +593,7 @@ exports["/list/`key`/`value`"] = {
       test.deepEqual(data[0].uniq, 3);
       test.done();
     });
-  }
+  },
 };
 
 exports["/list/`key`/`value`/data/`path...`"] = {
@@ -624,7 +626,7 @@ exports["/list/`key`/`value`/data/`path...`"] = {
       test.done();
     });
   },
-  "/data/`path...` multi": test => {
+  "/data/`path...` multi": (test) => {
     test.expect(2);
 
     mockGET("/list/hi/1/data/deep", (res, data) => {
@@ -633,7 +635,7 @@ exports["/list/`key`/`value`/data/`path...`"] = {
       test.done();
     });
   },
-  "no-matches": test => {
+  "no-matches": (test) => {
     test.expect(2);
 
     mockGET("/list/hi/3", (res, data) => {
@@ -642,7 +644,7 @@ exports["/list/`key`/`value`/data/`path...`"] = {
       test.done();
     });
   },
-  "/data/`path...` no-matches": test => {
+  "/data/`path...` no-matches": (test) => {
     test.expect(2);
 
     mockGET("/list/hi/3/data/deep", (res, data) => {
@@ -650,5 +652,5 @@ exports["/list/`key`/`value`/data/`path...`"] = {
       test.equal(data.length, 0);
       test.done();
     });
-  }
+  },
 };


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/NODE-37

**Overview:**
This change is part of an effort to standardize Clever's JS code formatting with prettier. I installed the latest version of prettier along with Clever's shared config, and formatted all source code. Any changes going forward will need to be formatted which can be done by running `make format`, or using a prettier editor plugin.

I also had to make a change to the JS version used by ESLint. ESLint uses es5 by default, however we need it to be on at least es2017/es8 to be able to parse trailing commas in function arguments. The ESLint config needs an overhaul, but I'll save that for another day. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas

I noticed that the repo is missing the node version check that we have in many other repos, so I went ahead and added that in here. I added a .nvmrc file too so we can run `nvm use` to conveniently switch to the correct node version.

**Testing:**

**Roll Out:**
