### PR TITLE
To no-homepod.

### DIFF
--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -49,7 +49,3 @@ alarms:
     source: ELB
 pod_config:
   group: us-west-1 # same region as its DynamoDBs
-  dev:
-    migrationState: podOnly
-  prod:
-    migrationState: podOnly


### PR DESCRIPTION
**Roll Out:**
The upstreams of `who-is-who` are:
```at 13:53:52 ❯ curl -s -H "X-Client-Version: 2.50.0" -XGET "https://production--catapult.int.clever.com/applications/who-is-who/upstreams" | jq '."who-is-who"' 
[
  "aws-cost-notifier",
  "who-is-who-syncer",
  "bookworm",
  "pickabot",
  "dapple",
  "dp-finalizer"
]
```
I have redeployed `who-is-who-syncer`, `pickabot`, `dapple`, and `dp-finalizer`. I am planning on deleting https://github.com/Clever/bookworm since it is no longer in use. And I am planning on graveyarding [aws-cost-notifier](https://github.com/Clever/aws-cost-notifier).

So all this is left after this is merged is to kill the old stacks.