### PR TITLE
remove alarm channel

### DIFF
--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -29,14 +29,12 @@ aws:
 alarms:
 - type: InternalErrorAlarm
   severity: minor
-  # channel: this will go to the channel that this team has configured in catapult for minor alarms
   parameters:
     threshold: 0.01
   extraParameters:
     source: Target
 - type: InternalErrorAlarm
   severity: major
-  # channel: this will go to the channel that this team has configured in catapult for major alarms
   parameters:
     threshold: 0.05
   extraParameters:


### PR DESCRIPTION
Removing this deprecated "channel" field. Alarms will instead go to the default channel for your team.

Please confirm that this looks correct, and then merge it
