### PR TITLE
Pass ownership to security.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,10 @@ jobs:
   build:
     working_directory: ~/Clever/who-is-who
     docker:
-    - image: circleci/golang:1.13.6-stretch-node
+    # It's awkward to find a way to simultaneously have the correct version of node and of Go
+    # Since this repo is primarly a node repo, we'll use our standard node image and install a version of go
+    # as a pre-built binary
+    - image: circleci/node:12-stretch
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
@@ -17,12 +20,21 @@ jobs:
         command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
         name: Set up CircleCI artifacts directories
     - run:
+        name: Install Go 1.16
+        command: |-
+          wget https://golang.org/dl/go1.16.8.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.16.8.linux-amd64.tar.gz
+    - run:
         command: |-
           sed -i.bak s/\${npm_auth_token}/$NPM_TOKEN/ .npmrc_docker
           mv .npmrc_docker .npmrc
         name: Set up .npmrc
     - run: npm install
-    - run: make test
+    - run:
+        name: Run tests
+        command: |
+          export PATH=$PATH:/usr/local/go/bin
+          make test
     - run: npm prune --production
     - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
     - run: $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Clever/eng-infra
+* @Clever/eng-security

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@ PRETTIER := ./node_modules/.bin/prettier
 all: test lint
 
 build-client:
-	go get -d -t github.com/Clever/who-is-who/go-client # fetch deps
-	go build go-client/client.go # ensures go client compiles
-	go test github.com/Clever/who-is-who/go-client # run tests
+	$(MAKE) -C go-client
 
 test: build-client lint
 	@./tests/run_integration_tests.sh

--- a/go-client/Makefile
+++ b/go-client/Makefile
@@ -1,0 +1,4 @@
+.PHONY:
+all:
+	go build .
+	go test .

--- a/go-client/go.mod
+++ b/go-client/go.mod
@@ -1,0 +1,5 @@
+module github.com/Clever/who-is-who/go-client
+
+go 1.16
+
+require github.com/hashicorp/go-retryablehttp v0.7.0

--- a/go-client/go.sum
+++ b/go-client/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
+github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -15,7 +15,7 @@ expose:
   health_check:
     type: http
     path: /health
-team: eng-infra
+team: eng-security
 aws:
   dynamodb:
     read:


### PR DESCRIPTION
Since this service is about identity and roles/attributes of Cleverites, we're passing ownership
from Infra to Security. Infra will continue to use it for use cases such as looking up a user's
Slack name from their Github name for Dapple, but the ownership will be Security.

As a parting gift, I tried to modernize a bit - change the CircleCI base image to Node to better reflect the fact that this is primarily a node repo, add a `go.mod` file, and make sure the Go client is tested on Go 1.16.