### PR TITLE
Tune alert to only alert critically when more than 50%

### DIFF
--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -28,13 +28,13 @@ aws:
     - whoswho-history
 alarms:
 - type: InternalErrorAlarm
-  severity: critical
+  severity: major
   parameters:
     threshold: 0.5
   extraParameters:
     source: Target
 - type: InternalErrorAlarm
-  severity: critical
+  severity: major
   parameters:
     threshold: 0.5
   extraParameters:

--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -28,21 +28,15 @@ aws:
     - whoswho-history
 alarms:
 - type: InternalErrorAlarm
-  severity: minor
+  severity: major
   parameters:
-    threshold: 0.01
+    threshold: 0.5
   extraParameters:
     source: Target
 - type: InternalErrorAlarm
   severity: major
   parameters:
-    threshold: 0.05
-  extraParameters:
-    source: Target
-- type: InternalErrorAlarm
-  severity: major
-  parameters:
-    threshold: 0.01
+    threshold: 0.5
   extraParameters:
     source: ELB
 pod_config:

--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -28,13 +28,13 @@ aws:
     - whoswho-history
 alarms:
 - type: InternalErrorAlarm
-  severity: major
+  severity: critical
   parameters:
     threshold: 0.5
   extraParameters:
     source: Target
 - type: InternalErrorAlarm
-  severity: major
+  severity: critical
   parameters:
     threshold: 0.5
   extraParameters:


### PR DESCRIPTION
**Jira:**

**Overview:**
This removes the noise we see in #oncall-security due to seldomly failing call. Upon successful retry, this error is resolved, hence let us alert only if more than 50% time, who-is-who is failing.

**Testing:**
👁️ 
**Roll Out:**
