### PR TITLE
migrate single region services to app mesh in mesh_only state in dev

### DIFF
--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -48,4 +48,4 @@ deploy_config:
   - production
 mesh_config:
   dev:
-    state: hybrid
+    state: mesh_only


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5113

**Overview:**
In this PR we will migrate all internal single region services in this repo to use app mesh in mesh_only state in **DEV** only. After this PR is merged the services will delete their loadbalancers. Going forward all the load balancing is done by envoy proxy.

An application in mesh can depend on any other application outside the mesh. But an application outside the mesh cannot depend on an application that is mesh_only. Engineers will still be able to access services using the usual URL but now we are going to share a single loadbalancer across all services!

Currently all apps are in hybrid mode which means that they are already using envoy for loadbalancing instead of using ALBs.

For more details on what each field in `mesh_config` means you can read https://app.getguru.com/card/TnAG64Gc/mesh_config-in-launchyml

Similar to other large scale infrastructure changes we expect some issues so if you think there are problems caused by this PR in dev please reach out to Tanmay or oncall-infra. 

**Rollout:**
- monitor cpu and memory

**Rollback:**
- ark rollback -e clever-dev <app>
- contact Tanmay or #oncall-infra