### PR TITLE
migrate services with some alb traffic to mesh_only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     # It's awkward to find a way to simultaneously have the correct version of node and of Go
     # Since this repo is primarly a node repo, we'll use our standard node image and install a version of go
     # as a pre-built binary
-    - image: circleci/node:14-stretch
+    - image: circleci/node:14-buster
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:14-buster
 
 WORKDIR /app
 

--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -50,4 +50,5 @@ mesh_config:
   dev:
     state: mesh_only
   prod:
-    state: hybrid
+    state: mesh_only
+  setupInternalRoute: true


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5118

**Overview:**
This PR is part of the second cohort of apps that we are migrating from hybrid to mesh_only.

All apps in this cohort are receiving some amount of requests through their ALB which means they pose a higher risk than the previous cohort of apps.

If this app is receiving traffic via the ALB, double check that `setupInternalRoute` is set to true so that routes are setup for lambdas and other clients to access this service once it is mesh_only and ALBs are removed.

If `setupInternalRoute` is not set then check where the requests are coming from before adding it.

https://clever.grafana.net/d/Kyms8kdVz/applications-envoy-alb?orgId=1&from=now-2d&to=now

**Rollout:**
- monitor cpu and memory
- monitor envoy metrics

**Rollback:**
- ark rollback -e clever-dev <app>
- contact Tanmay or #oncall-infra
