### PR TITLE
clean up alarms

### DIFF
--- a/launch/who-is-who.yml
+++ b/launch/who-is-who.yml
@@ -31,14 +31,6 @@ alarms:
   severity: major
   parameters:
     threshold: 0.5
-  extraParameters:
-    source: Target
-- type: InternalErrorAlarm
-  severity: major
-  parameters:
-    threshold: 0.5
-  extraParameters:
-    source: ELB
 pod_config:
   group: us-west-1 # same region as its DynamoDBs
 deploy_config:


### PR DESCRIPTION
# Clean up alarms for mesh services

## JIRA

https://clever.atlassian.net/browse/INFRANG-5475

## Overview

In Mesh there is no concept of alarm source of Target, ELB and Total as all metrics are coming from envoy sidecar. We are soon going to merge a change which will block CI for applications if source field is present for InternalErrorAlarms and mesh_config for prod set to mesh_only.

You have to review this PR to see that the new alarms make sense. It was hard to script all the different alarm setups we have across services. In most cases I have removed duplicate alarms but you might want to remove some more alarms or keep some deleted alarms.

## Rollout

Merge PR and deploy via dapple.
