### PR TITLE
add optional chaining to data access

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,4 +22,4 @@ env:
   mocha: true
 extends: 'eslint:recommended'
 parserOptions:
-  ecmaVersion: 2017
+  ecmaVersion: 2020

--- a/storage/dynamodb.js
+++ b/storage/dynamodb.js
@@ -104,7 +104,7 @@ function createWorkingExport(endpoint, region, accessId, secretKey) {
   let toObj = (obj, cb) => {
     var params = { TableName: objTable.TableName, Key: { _whoid: obj._whoid } };
     client.get(params, (err, data) => {
-      cb(err, data.Item);
+      cb(err, data?.Item);
     });
   };
 
@@ -115,7 +115,7 @@ function createWorkingExport(endpoint, region, accessId, secretKey) {
           return cb(err);
         }
 
-        cb(null, scan.Items);
+        cb(null, scan?.Items);
       });
     },
     has(key, cb) {
@@ -131,7 +131,7 @@ function createWorkingExport(endpoint, region, accessId, secretKey) {
           return cb(err);
         }
 
-        async.map(data.Items, toObj, cb);
+        async.map(data?.Items, toObj, cb);
       });
     },
     by(key, val, cb) {
@@ -147,7 +147,7 @@ function createWorkingExport(endpoint, region, accessId, secretKey) {
           return cb(err);
         }
 
-        async.map(data.Items, toObj, cb);
+        async.map(data?.Items, toObj, cb);
       });
     },
     history(whoid, path, cb) {
@@ -168,7 +168,7 @@ function createWorkingExport(endpoint, region, accessId, secretKey) {
           return cb(err);
         }
 
-        let results = data.Items.map((d) => _.omit(d, ["path_time"]));
+        let results = data?.Items.map((d) => _.omit(d, ["path_time"]));
         cb(null, results);
       });
     },


### PR DESCRIPTION
**Jira:**

**Overview:**
in oncall-security, getting pings about `TypeError`, which is due to queries resulting in no items, and we try to access empty `Item` field on null object data. As documentation for `GetItemOutput` says: `item` is optional on the returned data.
https://docs.aws.amazon.com/en_us/AWSJavaScriptSDK/v3/latest/clients/client-dynamodb/modules/getitemoutput.html  

https://app.datadoghq.com/logs?query=service%3Awho-is-who%20env%3Aproduction%20TypeError%20&cols=host%2Cservice&index=&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1694209791295&to_ts=1694468991295&live=true
**Testing:**
roll this out 
**Roll Out:**
