### PR TITLE
Filter out null values from response

### DIFF
--- a/router.js
+++ b/router.js
@@ -3,7 +3,8 @@ const _ = require("lodash");
 
 function omitId(objs) {
   if (Array.isArray(objs)) {
-    return objs.map(omitId);
+    // Filter out null or undefined items
+    return objs.filter(Boolean).map(omitId);
   } else if (_.isPlainObject(objs)) {
     return _.mapValues(_.omit(objs, "_whoid"), omitId);
   } else {


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/SHAPI-1677

**Overview:**
Noticed that Cleverville wasn't loading. Turns out that there are some null values in the response from who-is-who that's causing issues for Cleverville. I had the option to either 1. fix the data issue 2. make the fix in who-is-who so that null values won't be returned 3. make the fix in Cleverville where it filters out null values from who-is-who's response.

I'm not familiar with the source of the data, so option 1 wasn't possible. I also figured option 3 was too shallow since there could be other services that are using who-is-who who would also need to filter out the null values themselves. Returning null values from who-is-who seems to be undesirable, so option 2 felt like the best option.

**Testing:**
before (null values in who-is-who response)
![Screenshot 2025-05-27 at 2 34 02 AM](https://github.com/user-attachments/assets/99acf272-3d11-4a15-8bea-b41a4a9a34ec)

after
![Screenshot 2025-05-27 at 2 42 37 AM](https://github.com/user-attachments/assets/3f1a57c8-b327-464c-b8fa-d74382f2f859)

before (Cleverville stuck in loading screen)
![Screenshot 2025-05-27 at 2 50 14 AM](https://github.com/user-attachments/assets/237e1d5a-a755-46f7-b1a4-45f39a64ca3e)

after
![Screenshot 2025-05-27 at 2 50 57 AM](https://github.com/user-attachments/assets/79f6134a-52a0-47d3-a4ad-9ca1cebede86)

**Roll Out:**
💯 