### PR TITLE
fix(SECNG-4226): Fix DynamoDB table suffix

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,15 +9,9 @@ let port = process.env.PORT || "80";
 
 let endpoint = process.env.AWS_DYNAMO_ENDPOINT || "https://dynamodb.us-west-1.amazonaws.com/";
 let region = process.env.AWS_DYNAMO_REGION || "us-west-1";
-let tableNameSuffix = process.env.TABLE_NAME_SUFFIX;
 let dynamoReadWriteCapacity = parseInt(process.env.DYNAMO_READ_WRITE_CAPACITY, 10) || 5;
 
-const storage = require("./storage/dynamodb")(
-  endpoint,
-  region,
-  tableNameSuffix,
-  dynamoReadWriteCapacity,
-);
+const storage = require("./storage/dynamodb")(endpoint, region, dynamoReadWriteCapacity);
 const db = require("./db")(storage);
 const router = require("./router")(db);
 

--- a/storage/dynamodb.js
+++ b/storage/dynamodb.js
@@ -277,11 +277,10 @@ function createWorkingExport(endpoint, region /*credentials ignored*/) {
 }
 
 // entrypoint: export a "loading" wrapper until tables are ready (created in test, validated in prod)
-module.exports = function (endpoint, region, tableNameSuffix, readWriteCapacity) {
-  // apply suffix to table names & throughput
-  objTable.TableName += tableNameSuffix || "";
-  pathTable.TableName += tableNameSuffix || "";
-  histTable.TableName += tableNameSuffix || "";
+module.exports = function (endpoint, region, readWriteCapacity) {
+  objTable.TableName || "";
+  pathTable.TableName || "";
+  histTable.TableName || "";
 
   if (!Number.isInteger(readWriteCapacity)) {
     throw "Invalid dynamo read/write capacity: " + readWriteCapacity;

--- a/tests/test-routes.js
+++ b/tests/test-routes.js
@@ -6,7 +6,7 @@ const mocks = require("node-mocks-http");
 const async = require("async");
 
 let endpoint = process.env.AWS_DYNAMO_ENDPOINT;
-let storage = require("../storage/dynamodb")(endpoint, "us-west-1", "test", 1);
+let storage = require("../storage/dynamodb")(endpoint, "us-west-1", 1);
 
 const db = require("../db")(storage);
 const router = require("../router")(db);


### PR DESCRIPTION
**Clever Coding Standards Agreement**

- [ ] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

**Jira:**
[https://clever.atlassian.net/browse/SECNG-4226](https://clever.atlassian.net/browse/SECNG-4226)

**Overview:**
Table names were relying on a suffix supplied by env configuration. This removes that, so that table name declarations are a little more standard

**Testing:**
make test

**Roll Out:**